### PR TITLE
Fixing issues with comments and bash commands formatting

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -94,7 +94,7 @@ class Configuration(ConfigObject):
                additional_commands=None,
                always_wrap=None,
                algorithm_order=None,
-               enable_markup=True,
+               enable_markup=False,
                first_comment_is_literal=False,
                literal_comment_pattern=None,
                fence_pattern=None,

--- a/cmake_format/lexer.py
+++ b/cmake_format/lexer.py
@@ -105,6 +105,9 @@ def tokenize(contents):
       # https://stackoverflow.com/a/37379449/141023
       (r'(?<![^\s\(])"[^"\\]*(?:\\.[^"\\]*)*"(?![^\s\)])',
        lambda s, t: (TokenType.QUOTED_LITERAL, t)),
+      # bash commands
+      (r"[^(]*COMMAND (/bin/bash[^~]*?)fi\\\"\n",
+       lambda s, t: (TokenType.UNQUOTED_LITERAL, t)),
       # single quoted string
       (r"(?<![^\s\(])'[^'\\]*(?:\\.[^'\\]*)*'(?![^\s\)])",
        lambda s, t: (TokenType.QUOTED_LITERAL, t)),


### PR DESCRIPTION
This PR is **ready** for review.

**Summary**
This PR provides changes to formatting:
-Added new regex for Unquoted_Literal token due to excessive formatting of bash commands
-Disabled comment formatting as default

**CLA**
☑︎ I have signed the CLA